### PR TITLE
fix: bump the allowed framer-motion version

### DIFF
--- a/studio-v3.json
+++ b/studio-v3.json
@@ -25,7 +25,7 @@
     },
     {
       "description": "Use the latest stable and tested version of framer-motion used by sanity, @sanity/ui and @sanity/presentation",
-      "allowedVersions": "<=11.0.8",
+      "allowedVersions": "<=11.2.0",
       "matchDepTypes": ["dependencies", "devDependencies", "peerDependencies"],
       "matchPackageNames": ["framer-motion"],
       "rangeStrategy": "pin"


### PR DESCRIPTION
Relates to https://github.com/sanity-io/visual-editing/pull/1216