### PR TITLE
fix: pin framer-motion to an earlier version

### DIFF
--- a/studio-v3.json
+++ b/studio-v3.json
@@ -25,7 +25,7 @@
     },
     {
       "description": "Use the latest stable and tested version of framer-motion used by sanity, @sanity/ui and @sanity/presentation",
-      "allowedVersions": "<=11.2",
+      "allowedVersions": "11.0.8",
       "matchDepTypes": ["dependencies", "devDependencies", "peerDependencies"],
       "matchPackageNames": ["framer-motion"],
       "rangeStrategy": "pin"


### PR DESCRIPTION
`@sanity/ui` `Popover` animations don't run properly when the Studio is embedded in a Next.js canary app. This change downgrades `framer-motion` to the latest version we shipped `@sanity/ui` with and that we know works. We can upgrade again later once the underlying problem has been fixed.