### PR TITLE
fix: use `update-lockfile` rangeStrategy for Cargo.

### DIFF
--- a/strategy.json
+++ b/strategy.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Always widen `peerDependencies` and `engines`, while other types like `dependencies`, `devDependencies` are `update-lockfile`.",
+  "description": "Always widen `peerDependencies` and `engines`. npm `dependencies`/`devDependencies` use `bump`. Cargo dependencies use `update-lockfile`.",
   "packageRules": [
     {"matchDepTypes": ["engines", "peerDependencies"], "rangeStrategy": "widen"},
+    {"matchManagers": ["cargo"], "rangeStrategy": "update-lockfile"},
     {"groupName": "corepack", "matchDepTypes": ["packageManager"], "matchManagers": ["npm"]}
   ],
   "rangeStrategy": "bump"


### PR DESCRIPTION
Cargo's semver-range pinning differs from npm: `version = "0.6"` in `Cargo.toml` already means `^0.6`, so Renovate's `bump` strategy does not constrain the lockfile any further.

Switching Cargo to `update-lockfile` makes Renovate run `cargo update --precise` and bump only `Cargo.lock`, leaving the loose `Cargo.toml` ranges in place. This avoids the manifest-vs-lockfile mismatch entirely.
