### PR TITLE
fix: include min age exceptions in default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The default preset, `github>sanity-io/renovate-config`, is a composition of the 
     "github>sanity-io/renovate-config:node-lts",
     "github>sanity-io/renovate-config:typescript",
     "github>sanity-io/renovate-config:schedule",
+    "github>sanity-io/renovate-config:min-age-exceptions",
     "github>sanity-io/renovate-config:group-recommended",
     "github>sanity-io/renovate-config:group-non-major",
     "github>sanity-io/renovate-config:workarounds-esm",

--- a/default.json
+++ b/default.json
@@ -11,6 +11,7 @@
     "github>sanity-io/renovate-config:node-lts",
     "github>sanity-io/renovate-config:typescript",
     "github>sanity-io/renovate-config:schedule",
+    "github>sanity-io/renovate-config:min-age-exceptions",
     "github>sanity-io/renovate-config:group-recommended",
     "github>sanity-io/renovate-config:group-non-major",
     "github>sanity-io/renovate-config:workarounds-esm",

--- a/min-age-3days.json
+++ b/min-age-3days.json
@@ -1,36 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Wait 3 days before updating a package",
-  "packageRules": [
-    {
-      "description": "Exclude @sanity/* packages from minimumReleaseAge (no delay for internal packages)",
-      "matchPackageNames": [
-        "/^@next\\//",
-        "/^@oxfmt\\//",
-        "/^@oxlint-tsgolint\\//",
-        "/^@oxlint\\//",
-        "/^@portabletext\\//",
-        "/^@sanity\\//",
-        "/^@types\\//",
-        "/^eslint-plugin-oxlint$/",
-        "/^get-it$/",
-        "/^groq$/",
-        "/^groq-js$/",
-        "/^next$/",
-        "/^next-sanity$/",
-        "/^oxfmt$/",
-        "/^oxlint$/",
-        "/^oxlint-tsgolint$/",
-        "/^pnpm$/",
-        "/^react$/",
-        "/^react-dom$/",
-        "/^react-is$/",
-        "/^react-rx$/",
-        "/^sanity$/",
-        "/^use-effect-event$/"
-      ],
-      "minimumReleaseAge": "0 days"
-    }
-  ],
+  "extends": ["github>sanity-io/renovate-config:min-age-exceptions"],
   "minimumReleaseAge": "3 days"
 }

--- a/min-age-exceptions.json
+++ b/min-age-exceptions.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Disable minimum release age for packages that should be updated without delay",
+  "packageRules": [
+    {
+      "description": "Update Sanity packages without a minimum release age",
+      "matchPackageNames": [
+        "/^@portabletext\\//",
+        "/^@sanity\\//",
+        "/^get-it$/",
+        "/^groq$/",
+        "/^groq-js$/",
+        "/^next-sanity$/",
+        "/^react-rx$/",
+        "/^sanity$/",
+        "/^use-effect-event$/"
+      ],
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": "Update other trusted packages without a minimum release age",
+      "matchPackageNames": [
+        "/^@next\\//",
+        "/^@oxfmt\\//",
+        "/^@oxlint-tsgolint\\//",
+        "/^@oxlint\\//",
+        "/^@types\\//",
+        "/^eslint-plugin-oxlint$/",
+        "/^next$/",
+        "/^oxfmt$/",
+        "/^oxlint$/",
+        "/^oxlint-tsgolint$/",
+        "/^pnpm$/",
+        "/^react$/",
+        "/^react-dom$/",
+        "/^react-is$/"
+      ],
+      "minimumReleaseAge": "0 days"
+    }
+  ]
+}


### PR DESCRIPTION
`min-age-3days` includes a bunch of exceptions for trusted packages, but since that's not part of the default config, that meant internal Sanity packages were getting hit by the 24 hour delay before Renovate would allow them.

This moves the exceptions to a `min-age-exceptions` config, which `min-age-3days` extends.

I also split out the packages into two rules for readability, one for Sanity packages and one for trusted non-Sanity packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate preset JSON only; behavior change is faster updates for listed packages on the default preset, with no runtime or security surface.
> 
> **Overview**
> Trusted and Sanity packages were only exempt from **minimum release age** when using the `min-age-3days` preset, so repos on the default config still waited on internal packages like `@sanity/*`.
> 
> This PR introduces a shared **`min-age-exceptions`** preset with two `packageRules` (Sanity ecosystem vs other trusted deps, each with `minimumReleaseAge: "0 days"`), wires it into **`default.json`** and the README default `extends` list, and makes **`min-age-3days`** extend that preset instead of inlining the same rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c641712c0c7c53579be6e70771981e41aa0c6355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->